### PR TITLE
Update laspy and gdal imports

### DIFF
--- a/landcarve/commands/contour_image.py
+++ b/landcarve/commands/contour_image.py
@@ -1,6 +1,6 @@
 import os
 import click
-import gdal
+from osgeo import gdal
 import numpy
 import PIL.Image
 import skimage.measure

--- a/landcarve/commands/lasdem.py
+++ b/landcarve/commands/lasdem.py
@@ -63,7 +63,7 @@ def lasdem(
     with click.progressbar(length=len(input_paths), label="Opening files") as bar:
         for input_path in input_paths:
             bar.update(1)
-            las = laspy.file.File(input_path, mode="r")
+            las = laspy.read(input_path)
             las_files.append(las)
             las_projection = "unknown"
             for vlr in las.header.vlrs:
@@ -89,7 +89,7 @@ def lasdem(
     min_x, max_x, min_y, max_y = 1000000000, -1000000000, 1000000000, -1000000000
     num_points = 0
     for las in las_files:
-        num_points += las.points.shape[0]
+        num_points += las.points.array.size
         if ignore_header_range:
             min_x = min(min_x, las.x.min())
             max_x = max(max_x, las.x.max())
@@ -112,7 +112,7 @@ def lasdem(
     click.echo(f"Final DEM size {x_size}x{y_size}")
 
     # Create a new array to hold the data
-    arr = numpy.full((y_size, x_size), NODATA, dtype=numpy.float)
+    arr = numpy.full((y_size, x_size), NODATA, dtype=float)
     ignored_points = 0
 
     # For each point, bucket it into the right array coord

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
         "scikit-image~=0.16",
         "requests~=2.18",
         "simplification~=0.5",
-        "laspy~=1.7.0",
+        "laspy~=2.3.0",
     ],
     entry_points={"console_scripts": ["landcarve = landcarve.cli:main"]},
 )


### PR DESCRIPTION
* laspy 2.3 works on macOS, whereas I just outright gave up on getting
  1.7.0 to do so; lazperf just will not build back at 1.5.0, which was a
  transitive dependency
* gdal changed its import format in the latest, unpinned version. Fixed
  it!